### PR TITLE
Fix maven, Fix ctz_npc_id function, Add ctz_npc_click event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,11 +17,15 @@
 	<repositories>
 		<repository>
 			<id>sk89q-mvn2</id>
-			<url>http://mvn2.sk89q.com/repo</url>
+			<url>http://maven.sk89q.com/repo</url>
 		</repository>
 		<repository>
 			<id>citizensnpcs-repo</id>
 			<url>http://repo.citizensnpcs.co</url>
+		</repository>
+		<repository>
+			<id>spigotmc</id>
+			<url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/com/hekta/chcitizens/abstraction/MCCitizensNPC.java
+++ b/src/main/java/com/hekta/chcitizens/abstraction/MCCitizensNPC.java
@@ -1,6 +1,7 @@
 package com.hekta.chcitizens.abstraction;
 
 import java.util.Set;
+import java.util.UUID;
 
 import com.laytonsmith.abstraction.AbstractionObject;
 import com.laytonsmith.abstraction.MCEntity;
@@ -36,6 +37,7 @@ public interface MCCitizensNPC extends AbstractionObject {
 	public MCCitizensSpeechController getDefaultSpeechController();
 
 	public int getId();
+	public UUID getUniqueId();
 
 	public String getName();
 	public void setName(String name);

--- a/src/main/java/com/hekta/chcitizens/abstraction/bukkit/BukkitMCCitizensNPC.java
+++ b/src/main/java/com/hekta/chcitizens/abstraction/bukkit/BukkitMCCitizensNPC.java
@@ -2,6 +2,7 @@ package com.hekta.chcitizens.abstraction.bukkit;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.Location;
 
@@ -137,6 +138,11 @@ public class BukkitMCCitizensNPC implements MCCitizensNPC {
 	@Override
 	public int getId() {
 		return _npc.getId();
+	}
+
+	@Override
+	public UUID getUniqueId() {
+		return _npc.getUniqueId();
 	}
 
 	@Override

--- a/src/main/java/com/hekta/chcitizens/abstraction/bukkit/events/BukkitCitizensEvents.java
+++ b/src/main/java/com/hekta/chcitizens/abstraction/bukkit/events/BukkitCitizensEvents.java
@@ -1,11 +1,24 @@
 package com.hekta.chcitizens.abstraction.bukkit.events;
 
+import com.hekta.chcitizens.abstraction.events.MCCitizensEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNPCClickEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNPCDespawnEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNPCEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNPCSpawnEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationCancelEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationCompleteEvent;
+import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationEvent;
+import com.laytonsmith.abstraction.MCPlayer;
+import com.laytonsmith.abstraction.bukkit.entities.BukkitMCPlayer;
 import net.citizensnpcs.api.ai.event.NavigationCancelEvent;
 import net.citizensnpcs.api.ai.event.NavigationCompleteEvent;
 import net.citizensnpcs.api.ai.event.NavigationEvent;
 import net.citizensnpcs.api.event.CitizensEvent;
+import net.citizensnpcs.api.event.NPCClickEvent;
 import net.citizensnpcs.api.event.NPCDespawnEvent;
 import net.citizensnpcs.api.event.NPCEvent;
+import net.citizensnpcs.api.event.NPCLeftClickEvent;
+import net.citizensnpcs.api.event.NPCRightClickEvent;
 import net.citizensnpcs.api.event.NPCSpawnEvent;
 
 import com.laytonsmith.abstraction.Implementation;
@@ -21,17 +34,9 @@ import com.hekta.chcitizens.abstraction.enums.MCCitizensCancelReason;
 import com.hekta.chcitizens.abstraction.enums.MCCitizensDespawnReason;
 import com.hekta.chcitizens.abstraction.enums.bukkit.BukkitMCCitizensCancelReason;
 import com.hekta.chcitizens.abstraction.enums.bukkit.BukkitMCCitizensDespawnReason;
-import com.hekta.chcitizens.abstraction.events.MCCitizensEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNPCDespawnEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNPCEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNPCSpawnEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationCancelEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationCompleteEvent;
-import com.hekta.chcitizens.abstraction.events.MCCitizensNavigationEvent;
 import net.citizensnpcs.api.event.SpawnReason;
 
 /**
- *
  * @author Hekta
  */
 public class BukkitCitizensEvents {
@@ -148,7 +153,7 @@ public class BukkitCitizensEvents {
 		public Object _GetObject() {
 			return m_event;
 		}
-	
+
 		public static BukkitMCCitizensNPCDespawnEvent _instantiate(MCCitizensNPC npc, MCCitizensDespawnReason reason) {
 			return new BukkitMCCitizensNPCDespawnEvent(new NPCDespawnEvent(((BukkitMCCitizensNPC) npc).getHandle(), BukkitMCCitizensDespawnReason.getConvertor().getConcreteEnum(reason)));
 		}
@@ -181,6 +186,36 @@ public class BukkitCitizensEvents {
 		@Override
 		public MCLocation getLocation() {
 			return new BukkitMCLocation(m_event.getLocation());
+		}
+	}
+
+	@abstraction(type = Implementation.Type.BUKKIT)
+	public static class BukkitMCCitizensNPCClickEvent extends BukkitMCCitizensNPCEvent implements MCCitizensNPCClickEvent {
+		private final NPCClickEvent event;
+		private final boolean left;
+
+		public BukkitMCCitizensNPCClickEvent(NPCClickEvent e, boolean left) {
+			super(e);
+			this.event = e;
+			this.left = left;
+		}
+
+		public BukkitMCCitizensNPCClickEvent(NPCLeftClickEvent e) {
+			this(e, true);
+		}
+
+		public BukkitMCCitizensNPCClickEvent(NPCRightClickEvent e) {
+			this(e, false);
+		}
+
+		@Override
+		public MCPlayer getClicker() {
+			return new BukkitMCPlayer(event.getClicker());
+		}
+
+		@Override
+		public boolean isLeft() {
+			return left;
 		}
 	}
 }

--- a/src/main/java/com/hekta/chcitizens/abstraction/bukkit/events/BukkitCitizensListener.java
+++ b/src/main/java/com/hekta/chcitizens/abstraction/bukkit/events/BukkitCitizensListener.java
@@ -1,7 +1,10 @@
 package com.hekta.chcitizens.abstraction.bukkit.events;
 
+import net.citizensnpcs.api.event.NPCLeftClickEvent;
+import net.citizensnpcs.api.event.NPCRightClickEvent;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.Listener;
 
 import net.citizensnpcs.api.ai.event.NavigationCancelEvent;
@@ -14,7 +17,6 @@ import com.laytonsmith.core.events.Driver;
 import com.laytonsmith.core.events.EventUtils;
 
 /**
- *
  * @author Hekta
  */
 public class BukkitCitizensListener implements Listener {
@@ -29,10 +31,7 @@ public class BukkitCitizensListener implements Listener {
 	}
 
 	public static void unregister() {
-		NavigationCancelEvent.getHandlerList().unregister(_listener);
-		NavigationCompleteEvent.getHandlerList().unregister(_listener);
-		NPCDespawnEvent.getHandlerList().unregister(_listener);
-		NPCSpawnEvent.getHandlerList().unregister(_listener);
+		HandlerList.unregisterAll(_listener);
 	}
 
 	@EventHandler(priority = EventPriority.LOWEST)
@@ -45,13 +44,23 @@ public class BukkitCitizensListener implements Listener {
 		EventUtils.TriggerListener(Driver.EXTENSION, "ctz_npc_navigation_cancel", new BukkitCitizensEvents.BukkitMCCitizensNavigationCancelEvent(event));
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST)
+	@EventHandler(priority = EventPriority.LOWEST)
 	public void onNPCDespawn(NPCDespawnEvent event) {
 		EventUtils.TriggerListener(Driver.EXTENSION, "ctz_npc_despawn", new BukkitCitizensEvents.BukkitMCCitizensNPCDespawnEvent(event));
 	}
 
-	@EventHandler(priority=EventPriority.LOWEST)
+	@EventHandler(priority = EventPriority.LOWEST)
 	public void onNPCSpawn(NPCSpawnEvent event) {
 		EventUtils.TriggerListener(Driver.EXTENSION, "ctz_npc_spawn", new BukkitCitizensEvents.BukkitMCCitizensNPCSpawnEvent(event));
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onNPCLeftClick(NPCLeftClickEvent e) {
+		EventUtils.TriggerListener(Driver.EXTENSION, "ctz_npc_click", new BukkitCitizensEvents.BukkitMCCitizensNPCClickEvent(e));
+	}
+
+	@EventHandler(priority = EventPriority.LOWEST)
+	public void onNPCRightClick(NPCRightClickEvent e) {
+		EventUtils.TriggerListener(Driver.EXTENSION, "ctz_npc_click", new BukkitCitizensEvents.BukkitMCCitizensNPCClickEvent(e));
 	}
 }

--- a/src/main/java/com/hekta/chcitizens/abstraction/events/MCCitizensNPCClickEvent.java
+++ b/src/main/java/com/hekta/chcitizens/abstraction/events/MCCitizensNPCClickEvent.java
@@ -1,0 +1,9 @@
+package com.hekta.chcitizens.abstraction.events;
+
+import com.laytonsmith.abstraction.MCPlayer;
+
+public interface MCCitizensNPCClickEvent extends MCCitizensNPCEvent {
+    boolean isLeft();
+
+    MCPlayer getClicker();
+}

--- a/src/main/java/com/hekta/chcitizens/core/events/CitizensEvents.java
+++ b/src/main/java/com/hekta/chcitizens/core/events/CitizensEvents.java
@@ -343,7 +343,7 @@ public final class CitizensEvents {
 				MCEntity entity = npc.getEntity();
 				ret.put("button", new CString(left ? "left" : "right", t));
 				ret.put("player", new CString(event.getClicker().getName(), t));
-				ret.put("id", new CInt(npc.getId(), t));
+				ret.put("npc", new CInt(npc.getId(), t));
 				ret.put("entity", new CString(npc.getUniqueId().toString(), t));
 				ret.put("type", new CString(entity.getType().name(), t));
 				ret.put("location", ObjectGenerator.GetGenerator().location(new BukkitMCLocation(entity.getLocation())));

--- a/src/main/java/com/hekta/chcitizens/core/functions/CitizensManagement.java
+++ b/src/main/java/com/hekta/chcitizens/core/functions/CitizensManagement.java
@@ -29,6 +29,8 @@ import com.laytonsmith.core.exceptions.CRE.CREThrowable;
 import com.laytonsmith.core.exceptions.ConfigRuntimeException;
 import com.laytonsmith.core.natives.interfaces.Mixed;
 
+import java.util.UUID;
+
 /**
  *
  * @author Hekta
@@ -170,7 +172,8 @@ public abstract class CitizensManagement extends CitizensFunctions {
 
 		@Override
 		public Mixed exec(Target t, Environment environment, Mixed... args) throws ConfigRuntimeException {
-			MCCitizensNPC npc = CHCitizensStatic.getNPCRegistry(t).getNPC(Static.getEntity(args[0], t));
+			UUID uuid = Static.GetUUID(args[0], t);
+			MCCitizensNPC npc = CHCitizensStatic.getNPCRegistry(t).getNPC(uuid);
 			if (npc != null) {
 				return new CInt(npc.getId(), t);
                         } else {


### PR DESCRIPTION
In my case, I couldn't get the npc id(number) by uuid of bukkit entity using ctz_npc_id().
So I tried to know why it happens and I known that citizen's npc entities are not be register to bukkit entities map. so we can't get an npc entity using `Bukkit.getEntity(uuid)`
And not equals bukkit entity's uuid and citizen's internal uuid. so weired.
So I added ctz_npc_click event and fix ctz_npc_id to do not gettering entity.
It works fine in CH 3.3.4, Citizens-2.0.25-b1738 latest versions